### PR TITLE
ADD explicit version for nosetests dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,4 @@
 nose==1.3.7
 nose-cov==1.6
+coverage==3.7.1
+


### PR DESCRIPTION
#### Reviewers

@chemaper 
#### Description

It is needed downloading that version (and not the last one) to avoid building problems. `nose-cov` lib is not managing its dependencies properly.
#### Testing

Jenkins.
