### PR TITLE
fix:usr:shows warning message when images are replaced because differ…

### DIFF
--- a/glancesync/glancesync.py
+++ b/glancesync/glancesync.py
@@ -186,7 +186,7 @@ class GlanceSync(object):
                 uploaded = True
                 region_image = dictimages[tuple[1].name]
                 if not dry_run:
-                    self.log.info(regionobj.fullname + ': Replacing image ' +
+                    self.log.warn(regionobj.fullname + ': Replacing image ' +
                                   tuple[1].name + ' (' + str(sizeimage) +
                                   ' MB)')
                     self.__upload_image(tuple[1], dictimages, regionobj)
@@ -196,7 +196,7 @@ class GlanceSync(object):
                 uploaded = True
                 region_image = dictimages[tuple[1].name]
                 if not dry_run:
-                    self.log.info(
+                    self.log.warn(
                         regionobj.fullname + ': Renaming and replacing image '
                         + tuple[1].name + ' (' + str(sizeimage) + ' MB)')
                     self.__upload_image(tuple[1], dictimages, regionobj)


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos 
#### Description

It shows a  warning  level message instead of an info level message when an image is replaced.

A new test method was added, also.
#### Testing

Locally
