### PR TITLE
Bug/claudia 5415

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,8 +88,9 @@ metadata field to simulate it.
 The downside of using names, is that a region may have more than a image
 with the same name. This is specially challenging, when there is more than one
 image in a destination target, with the name of the image to synchronise. In
-this situation, GlanceSync takes the first that it found and print a warning with
-the others.
+this situation, GlanceSync takes the first image that is found with the same checkum
+(or absolutely the first image that is found if there is not a checksum match)
+and prints a warning for each duplicated image detected.
 
 Image names with duplicated names are easy to avoid, with one serious
 exception: when ordinary users can publish their images as public (shared), the

--- a/glancesync/glancesync.py
+++ b/glancesync/glancesync.py
@@ -78,13 +78,7 @@ class GlanceSync(object):
         self.max_children = glancesyncconfig.max_children
         master_region = GlanceSyncRegion(self.master_region, self.targets)
         images = master_region.target['facade'].get_imagelist(master_region)
-        # Ignore (public) images of other tenants
-        tenant_id = target['facade'].get_tenant_id().zfill(32)
-        imgs = list(image for image in images if not image.owner or
-                    image.owner == '' or image.owner.zfill(32) == tenant_id)
-        # replace kernel_id, ramdisk_id with image name
-        self.master_region_dict = glancesync_ami.get_master_region_dict(imgs)
-
+        self.master_region_dict = glancesync_ami.get_master_region_dict(images)
 
     def get_regions(self, omit_master_region=True, target='master'):
         """It returns the list of regions

--- a/glancesync/glancesync.py
+++ b/glancesync/glancesync.py
@@ -65,27 +65,26 @@ class GlanceSync(object):
         self.targets = glancesyncconfig.targets
         count = 0
         for target in self.targets.values():
-            if 'facade_module' in target:
-                import_code = 'from ' + target['facade_module'] +\
-                              'import ServersFacade as Facade' + str(count)
-                instance_code = 'Facade' + str(count) + '(target)'
-                exec import_code
-                target['facade'] = eval(instance_code)
+            if 'GLANCESYNC_USE_MOCK' in os.environ:
+                target['facade'] = ServersFacadeMock(target)
+            elif 'GLANCESYNC_MOCKPERSISTENT_PATH' in os.environ:
+                target['facade'] = ServersFacadeMock(target)
+                target['facade'].init_persistence(
+                    os.environ['GLANCESYNC_MOCKPERSISTENT_PATH'])
             else:
-                if 'GLANCESYNC_USE_MOCK' in os.environ:
-                    target['facade'] = ServersFacadeMock(target)
-                elif 'GLANCESYNC_MOCKPERSISTENT_PATH' in os.environ:
-                    target['facade'] = ServersFacadeMock(target)
-                    target['facade'].init_persistence(
-                        os.environ['GLANCESYNC_MOCKPERSISTENT_PATH'])
-                else:
-                    target['facade'] = ServersFacade(target)
+                target['facade'] = ServersFacade(target)
 
         self.preferable_order = glancesyncconfig.preferable_order
         self.max_children = glancesyncconfig.max_children
         master_region = GlanceSyncRegion(self.master_region, self.targets)
         images = master_region.target['facade'].get_imagelist(master_region)
-        self.master_region_dict = glancesync_ami.get_master_region_dict(images)
+        # Ignore (public) images of other tenants
+        tenant_id = target['facade'].get_tenant_id().zfill(32)
+        imgs = list(image for image in images if not image.owner or
+                    image.owner == '' or image.owner.zfill(32) == tenant_id)
+        # replace kernel_id, ramdisk_id with image name
+        self.master_region_dict = glancesync_ami.get_master_region_dict(imgs)
+
 
     def get_regions(self, omit_master_region=True, target='master'):
         """It returns the list of regions
@@ -185,25 +184,34 @@ class GlanceSync(object):
             elif tuple[0] == 'pending_replace':
                 uploaded = True
                 region_image = dictimages[tuple[1].name]
-                if not dry_run:
-                    self.log.warn(regionobj.fullname + ': Replacing image ' +
+                self.log.info(regionobj.fullname + ': Replacing image ' +
                                   tuple[1].name + ' (' + str(sizeimage) +
                                   ' MB)')
+                if not dry_run:
                     self.__upload_image(tuple[1], dictimages, regionobj)
                     facade.delete_image(regionobj, region_image.id,
                                         confirm=False)
             elif tuple[0] == 'pending_rename_n_replace':
                 uploaded = True
                 region_image = dictimages[tuple[1].name]
+                self.log.info(
+                    regionobj.fullname + ': Renaming and replacing image '
+                    + tuple[1].name + ' (' + str(sizeimage) + ' MB)')
+
                 if not dry_run:
-                    self.log.warn(
-                        regionobj.fullname + ': Renaming and replacing image '
-                        + tuple[1].name + ' (' + str(sizeimage) + ' MB)')
                     self.__upload_image(tuple[1], dictimages, regionobj)
                     region_image.name += '.old'
                     region_image.is_public = False
                     facade.update_metadata(regionobj, region_image)
-
+            elif tuple[0] == 'error_checksum':
+                msg =\
+                    'Image {0} has a different checksum ({2}) in region {1} '\
+                    'than in the master region. It was not set what to do. '\
+                    'Please, fill either dontupdate, replace or rename '\
+                    'with the checksum.'
+                self.log.warning(msg.format(region_image.name,
+                                            regionobj.fullname,
+                                            region_image.checksum))
             if uploaded:
                 was_synchronised = False
                 totalmbs += sizeimage

--- a/scripts/support/requirements.txt
+++ b/scripts/support/requirements.txt
@@ -6,3 +6,5 @@ oslo.config==1.9.3
 oslo.i18n==1.5.0
 oslo.serialization==1.4.0
 oslo.utils==1.4.0
+requests==2.6.0
+

--- a/tests/unit/test_glancesync.py
+++ b/tests/unit/test_glancesync.py
@@ -463,9 +463,8 @@ class TestGlanceSync_Checksum(TestGlanceSync_Sync):
         self.regions = ['master:Burgos']
 
     def test_sync_warning(self):
-        """test that two warnings are emitted when replacing images with
-        a different checksum. The first one is a rename and replace warning
-        and the second one a replace warning"""
+        """test that a warning is emitted with a image that has a
+        different checksum and there is not settings about what to do with."""
         # Capture warnings
         logger = logging.getLogger('glancesync')
         self.buffer_log = StringIO.StringIO()
@@ -479,11 +478,11 @@ class TestGlanceSync_Checksum(TestGlanceSync_Sync):
 
         # Check that there are two warnings
         warnings = self.buffer_log.getvalue().splitlines()
-        self.assertEquals(len(warnings), 2)
-        msg1 = 'Burgos: Renaming and replacing image image02'
-        msg2 = 'Burgos: Replacing image image04'
+        self.assertEquals(len(warnings), 1)
+        msg1 = 'Image image04 has a different checksum (ch4) in region Burgos'\
+               ' than in the master region. It was not set what to do. Please'\
+               ', fill either dontupdate, replace or rename with the checksum.'
         self.assertTrue(warnings[0].startswith(msg1))
-        self.assertTrue(warnings[1].startswith(msg2))
 
 class TestGlanceSync_AMI(TestGlanceSync_Sync):
     """Test a environment with AMI images (kernel_id/ramdisk_id)"""


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos 
#### Description

Fixes BUG 5415, about a warning with checksums

Fixing this bug another bug/bad behaviour was detected. When two images with the same name
are detected, this is an anomaly an a warning is printed, but it is not an error fatal and glancesync takes the first image and discard the others.  Now it takes precedence an image with the same checksum than master if it exists.

Also fix a problem with a dependency: request was added with a specific version, because the last one does not works correctly with the python-glance module.
#### Testing

Locally
