### PR TITLE
Bug/claudia 5414

### DIFF
--- a/glancesync/glancesync.py
+++ b/glancesync/glancesync.py
@@ -78,13 +78,7 @@ class GlanceSync(object):
         self.max_children = glancesyncconfig.max_children
         master_region = GlanceSyncRegion(self.master_region, self.targets)
         images = master_region.target['facade'].get_imagelist(master_region)
-        # Ignore (public) images of other tenants
-        tenant_id = target['facade'].get_tenant_id().zfill(32)
-        imgs = list(image for image in images if not image.owner or
-                    image.owner == '' or image.owner.zfill(32) == tenant_id)
-        # replace kernel_id, ramdisk_id with image name
-        self.master_region_dict = glancesync_ami.get_master_region_dict(imgs)
-
+        self.master_region_dict = glancesync_ami.get_master_region_dict(images)
 
     def get_regions(self, omit_master_region=True, target='master'):
         """It returns the list of regions

--- a/sync.py
+++ b/sync.py
@@ -31,7 +31,7 @@ import datetime
 import argparse
 import logging
 
-from glancesync.glancesync_fi import GlanceSyncFi as GlanceSync
+from glancesync.glancesync import GlanceSync
 
 
 class Sync(object):
@@ -122,7 +122,6 @@ class Sync(object):
         :param dry_run: if true, do not synchronise images actually
         """
         print '======Master (' + self.glancesync.master_region + ')'
-        self.glancesync.print_images_master_region()
 
         for region in self.regions:
             try:


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos 
#### Description

Remove printing of images with NID and type in three groups before synchronisation (BUG 5414)

This is obsolete and not very useful (the list can be obtained with examples/printimages.py anyway).

This is here from first version, but it is very specific of FIWARE. Even when used with FIWARE it may be confusing because it may not reflect the images that are synchronised (e.g. if the criteria selection is changed, or if there is several targets).
#### Testing

Locally
