### PR TITLE
Bug/claudia 5413

### DIFF
--- a/glancesync/glancesync.py
+++ b/glancesync/glancesync.py
@@ -407,7 +407,8 @@ class GlanceSync(object):
         metadata_set = regionobj.target['metadata_set']
         properties = list(new_image.user_properties.keys())
         for p in properties:
-            if p not in metadata_set:
+            if p not in metadata_set and \
+                    p != 'kernel_id' and p != 'ramdisk_id':
                 del new_image.user_properties[p]
 
         # upload

--- a/glancesync/glancesync_ami.py
+++ b/glancesync/glancesync_ami.py
@@ -83,8 +83,8 @@ def update_kernelramdisk_id(image, master_image, region_images):
     The function returns True if the object has been modified and need to be
     updated.
 
-    If the kernel or ramdisk image is not found, a warning is emitted, the
-    image is marked as private and the kernel_id/ramdisk_id is filled with the
+    If the kernel or ramdisk image is not found, a warning is emitted
+    and the kernel_id/ramdisk_id is filled with the
     name of the missing image with the prefix __
 
     if the ramdisk_id/kernel_id is present in image but not in master image,
@@ -103,8 +103,7 @@ def update_kernelramdisk_id(image, master_image, region_images):
     return r1 or r2
 
 
-def _update_auximg_id(property_id, image, master_image, images_region,
-                      dry_run=False):
+def _update_auximg_id(property_id, image, master_image, images_region):
     """
     Utility function that modify, if required, a property in the image
     pointing to the id of other image. For example, it is used with kernel_id
@@ -114,7 +113,6 @@ def _update_auximg_id(property_id, image, master_image, images_region,
     :param image: the image to modify
     :param master_image: the master image
     :param images_region: a dictionary indexed by name with the region's images
-    :param dry_run: if true, don't modify the image, only check it is required
     :return:
     """
     if property_id not in master_image.user_properties:
@@ -123,21 +121,17 @@ def _update_auximg_id(property_id, image, master_image, images_region,
             return False
         else:
             # remove property
-            if not dry_run:
-                del image.user_properties[property_id]
+            del image.user_properties[property_id]
             return True
 
     # Get the name of the kernel/ramdisk image
     aux_image_name = master_image.user_properties[property_id]
     if aux_image_name not in images_region:
-        if dry_run:
-            return True
         # It is very unusual that an image exists and not its kernel or
         # ramdisk, because little images are upload first, but it is
         # possible (e.g. if the image is removed manually or it is
         # replaced by a more recent one)
-        # In this case, print a warning and mark the image as private
-        image.is_public = False
+        # In this case, print a warning
         msg = '{1}: Not found {0} on region. It should be {2} of image {3}'
         _logger.warning(msg.format(aux_image_name, image.region,
                                    property_id, image.name))
@@ -150,8 +144,7 @@ def _update_auximg_id(property_id, image, master_image, images_region,
     if property_id in image.user_properties and\
             aux_image.id == image.user_properties[property_id]:
         return False
-    if not dry_run:
-        image.user_properties[property_id] = aux_image.id
+    image.user_properties[property_id] = aux_image.id
     return True
 
 
@@ -171,7 +164,7 @@ def check_ami(image, master_image, region_images, pending_images):
 
     Typically, images with state 'ready' can be ignored; images with state
     'update' can be updated before uploading the pending images. Images with
-    'missing' state must be updated after the uploading of pending images.
+    'pending' state must be updated after the uploading of pending images.
     Finally, images with 'missing' state are broken.
 
     :param image: the image to check

--- a/glancesync/glancesync_serverfacade_mock.py
+++ b/glancesync/glancesync_serverfacade_mock.py
@@ -251,6 +251,9 @@ class ServersFacade(object):
                     ServersFacade.images[region_name] = dict()
             with open(file) as f:
                 for row in csv.reader(f):
+                    # ignore blank lines
+                    if len(row) == 0:
+                        continue
                     image = GlanceSyncImage.from_field_list(row)
                     ServersFacade.images[region_name][image.id] = image
             if ServersFacade.use_persistence:

--- a/tests/resources/ami.result/backup_Burgos.csv
+++ b/tests/resources/ami.result/backup_Burgos.csv
@@ -8,3 +8,6 @@ Burgos,image07,107,active,1000,39f193cfd7d0955cc821f3074a82b7d4b89d22bc,tenant1i
 Burgos,image08,108,active,1000,1ea51bf32497d1b3708522b430b288a129f65307,tenant1id,True,{'type': 'ramdisk'}
 Burgos,image09,109,active,1073741904,4b581cdce6283495fd4934ce574ac47e92881c64,tenant1id,True,"{'type': 'image', 'kernel_id': '107', 'ramdisk_id': '108'}"
 Burgos,image10,110,active,1073741914,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,"{'kernel_id': '111', 'ramdisk_id': '112'}"
+Burgos,image13,1$image13,active,1001,ddfe163345d338193ac2bdc183f8e9dcff904b43,tenant1id,True,{'type': 'kernel'}
+Burgos,image14,1$image14,active,1001,bcac9d1d8eab3713ae489224d0130c9468e7a0e3,tenant1id,True,{'type': 'ramdisk'}
+Burgos,image15,1$image15,active,2073741845,3ea6c91e241f256e5e3a88ebd647372022323a55,tenant1id,True,"{'type': 'image', 'kernel_id': '1$image13', 'ramdisk_id': '1$image14'}"

--- a/tests/resources/ami.result/backup_Valladolid.csv
+++ b/tests/resources/ami.result/backup_Valladolid.csv
@@ -9,4 +9,7 @@ Valladolid,image08,008,active,1000,1ea51bf32497d1b3708522b430b288a129f65307,tena
 Valladolid,image09,009,active,1073741904,4b581cdce6283495fd4934ce574ac47e92881c64,tenant1id,True,"{'type': 'image', 'kernel_id': '007', 'ramdisk_id': '008'}"
 Valladolid,image10,010,active,1073741914,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,"{'type': 'image', 'kernel_id': '011', 'ramdisk_id': '012'}"
 Valladolid,image11,011,active,1000,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,{}
-Valladolid,image11,012,active,1000,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,{}
+Valladolid,image12,012,active,1000,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,{}
+Valladolid,image13,013,active,1001,ddfe163345d338193ac2bdc183f8e9dcff904b43,tenant1id,True,{'type': 'kernel'}
+Valladolid,image14,014,active,1001,bcac9d1d8eab3713ae489224d0130c9468e7a0e3,tenant1id,True,{'type': 'ramdisk'}
+Valladolid,image15,015,active,2073741845,3ea6c91e241f256e5e3a88ebd647372022323a55,tenant1id,True,"{'type': 'image', 'kernel_id': '013', 'ramdisk_id': '014'}"

--- a/tests/resources/ami.status_post/Burgos.csv
+++ b/tests/resources/ami.status_post/Burgos.csv
@@ -4,7 +4,10 @@ ok,Burgos,image04
 ok,Burgos,image05
 ok,Burgos,image07
 ok,Burgos,image08
+ok,Burgos,image13
+ok,Burgos,image14
 ok,Burgos,image03
 ok,Burgos,image06
 ok,Burgos,image09
 error_ami,Burgos,image10
+ok,Burgos,image15

--- a/tests/resources/ami.status_pre/Burgos.csv
+++ b/tests/resources/ami.status_pre/Burgos.csv
@@ -4,7 +4,10 @@ pending_upload,Burgos,image04
 pending_metadata,Burgos,image05
 pending_metadata,Burgos,image07
 pending_metadata,Burgos,image08
+pending_upload,Burgos,image13
+pending_upload,Burgos,image14
 pending_metadata,Burgos,image03
 pending_ami,Burgos,image06
 ok,Burgos,image09
 error_ami,Burgos,image10
+pending_upload,Burgos,image15

--- a/tests/resources/ami/backup_Valladolid.csv
+++ b/tests/resources/ami/backup_Valladolid.csv
@@ -9,4 +9,8 @@ Valladolid,image08,008,active,1000,1ea51bf32497d1b3708522b430b288a129f65307,tena
 Valladolid,image09,009,active,1073741904,4b581cdce6283495fd4934ce574ac47e92881c64,tenant1id,True,"{'type': 'image', 'kernel_id': '007', 'ramdisk_id': '008'}"
 Valladolid,image10,010,active,1073741914,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,"{'type': 'image', 'kernel_id': '011', 'ramdisk_id': '012'}"
 Valladolid,image11,011,active,1000,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,{}
-Valladolid,image11,012,active,1000,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,{}
+Valladolid,image12,012,active,1000,b1d5781111d84f7b3fe45a0852e59758cd7a87e5,tenant1id,True,{}
+Valladolid,image13,013,active,1001,ddfe163345d338193ac2bdc183f8e9dcff904b43,tenant1id,True,{'type': 'kernel'}
+Valladolid,image14,014,active,1001,bcac9d1d8eab3713ae489224d0130c9468e7a0e3,tenant1id,True,{'type': 'ramdisk'}
+Valladolid,image15,015,active,2073741845,3ea6c91e241f256e5e3a88ebd647372022323a55,tenant1id,True,"{'type': 'image', 'kernel_id': '013', 'ramdisk_id': '014'}"
+

--- a/tests/unit/test_glancesync.py
+++ b/tests/unit/test_glancesync.py
@@ -381,8 +381,9 @@ class TestGlanceSync_Sync(unittest.TestCase):
                 region = region[7:]
             self.assertTrue(os.path.exists(path_status))
             f = open(path_status + '/' + region + '.csv', 'rU')
-            expected = f.read().replace('\n', '\r\n')
+            expected = f.read().replace('\n', ';')
             result = stream.getvalue()
+            result = result.replace('\r\n', ';')
             self.assertEquals(expected, result)
 
     def test_sync(self):
@@ -423,8 +424,8 @@ class TestGlanceSync_Sync(unittest.TestCase):
                 region = region[7:]
             self.assertTrue(os.path.exists(path_status))
             f = open(path_status + '/' + region + '.csv', 'rU')
-            expected = f.read().replace('\n', '\r\n')
-            result = stream.getvalue()
+            expected = f.read().replace('\n', ';')
+            result = stream.getvalue().replace('\r\n', ';')
             self.assertEquals(expected, result)
 
 


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos 
#### Description

Fix BUG 5413, about a problem with AMI images

The problem was that after uploading a new AMI images, kernel_id and ramdisk_id are not updated correctly and the image is in state ami_pending.

The test was changed to reproduce the bug.

The problem was because the method that upload the image cleaned the kernel_id and ramdisk_id
#### Testing

Locally
