### PR TITLE
Fix/documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -741,7 +741,7 @@ run the synchronisation:
  done
 
  # run synchronisation
- ./sync.py $* --config images_dir=$GLANCE_IMAGES $*
+ ./sync.py $* --config images_dir=$GLANCE_IMAGES
 
 
 Top_


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos 
#### Description

Several fixes in documentation, with some changes in the last pull request that were not well clarified. For example about not synchronising duplicated images or images from other tenants.

In addition, it is a comment about using -- after --config  if regions are specified at the end.

Finally, a new subsection was added with an example for pre-downloading images, when there is
not physical access to /var/lib/glance/images.
#### Testing

Locally
