### PR TITLE
bug/CLAUDIA-5417_metadataset_problem

### DIFF
--- a/glancesync/glancesync_serversfacade.py
+++ b/glancesync/glancesync_serversfacade.py
@@ -135,6 +135,7 @@ class ServersFacade(object):
                               disk_format=image.raw['disk_format'],
                               protected=image.raw['protected'],
                               container_format=image.raw['container_format'],
+                              purge_props=True,
                               properties=image.user_properties)
         except Exception, e:
             msg = regionobj.fullname + ': Update of ' + image.name +\

--- a/tests/acceptance/features/glancesync/metadata_image.feature
+++ b/tests/acceptance/features/glancesync/metadata_image.feature
@@ -253,7 +253,6 @@ Feature: Image sync between regions using GlanceSync in the same federation but
               | new_att         | qa-test             |
 
 
-    @skip @bug @CLAUDIA-5315
     Scenario: 09a: Sync already existent images when its metadata have changed. Remove attribute. Same configuration properties.
       Given a new image created in the Glance of master node with name "qatesting01" and these properties:
               | param_name      | param_value         |
@@ -279,7 +278,6 @@ Feature: Image sync between regions using GlanceSync in the same federation but
               | sdc_aware       | True                |
 
 
-    @skip @bug @CLAUDIA-5315
     Scenario: 09b: Sync already existent images when its metadata have changed. Remove and edit attributes. Same configuration properties.
       Given a new image created in the Glance of master node with name "qatesting01" and these properties:
               | param_name      | param_value         |

--- a/tests/unit/resources/metadata.result/backup_Burgos.csv
+++ b/tests/unit/resources/metadata.result/backup_Burgos.csv
@@ -2,3 +2,4 @@ Burgos,image01,101,active,1073741824,ddfe163345d338193ac2bdc183f8e9dcff904b43,te
 Burgos,image02,102,active,1073741834,bcac9d1d8eab3713ae489224d0130c9468e7a0e3,tenant1id,True,"{'type': 'baseimage', 'k1': 'v100'}"
 Burgos,image03,103,active,1073741844,3ea6c91e241f256e5e3a88ebd647372022323a53,tenant1id,False,"{'type': 'ngimages', 'nid': 2, 'k3': 'v3'}"
 Burgos,image04,1$image04,active,1073741854,798f861ee74f6ff83ccbc9c53b419941d0080e50,tenant1id,True,"{'type': 'other'}"
+Burgos,image05,105,active,1073741864,44a6c91e241f256e5e3a88ebd647372022323a53,tenant1id,True,"{'type': 'ngimages', 'k4': 'v3'}"

--- a/tests/unit/resources/metadata.result/backup_Valladolid.csv
+++ b/tests/unit/resources/metadata.result/backup_Valladolid.csv
@@ -2,3 +2,4 @@ Valladolid,image01,001,active,1073741824,ddfe163345d338193ac2bdc183f8e9dcff904b4
 Valladolid,image02,002,active,1073741834,bcac9d1d8eab3713ae489224d0130c9468e7a0e3,tenant1id,True,"{'type': 'baseimage', 'k1': 'v1'}"
 Valladolid,image03,003,active,1073741844,3ea6c91e241f256e5e3a88ebd647372022323a53,tenant1id,False,"{'type': 'ngimages', 'nid': 2, 'k3': 'v3'}"
 Valladolid,image04,004,active,1073741854,798f861ee74f6ff83ccbc9c53b419941d0080e50,tenant1id,True,"{'type': 'other', 'k1' : 'value1'}"
+Valladolid,image05,005,active,1073741864,44a6c91e241f256e5e3a88ebd647372022323a53,tenant1id,True,"{'type': 'ngimages', 'k3': 'v3'}"

--- a/tests/unit/resources/metadata.status_post/Burgos.csv
+++ b/tests/unit/resources/metadata.status_post/Burgos.csv
@@ -1,3 +1,4 @@
 ok,Burgos,image01
 ok,Burgos,image02
 ok,Burgos,image04
+ok,Burgos,image05

--- a/tests/unit/resources/metadata.status_pre/Burgos.csv
+++ b/tests/unit/resources/metadata.status_pre/Burgos.csv
@@ -1,3 +1,4 @@
 pending_metadata,Burgos,image01
 ok,Burgos,image02
 pending_upload,Burgos,image04
+pending_metadata,Burgos,image05

--- a/tests/unit/resources/metadata/backup_Burgos.csv
+++ b/tests/unit/resources/metadata/backup_Burgos.csv
@@ -1,3 +1,4 @@
 Burgos,image01,101,active,1073741824,ddfe163345d338193ac2bdc183f8e9dcff904b43,tenant1id,True,"{'type': 'ngimages', 'nid': 0}"
 Burgos,image02,102,active,1073741834,bcac9d1d8eab3713ae489224d0130c9468e7a0e3,tenant1id,True,"{'type': 'baseimage', 'k1': 'v100'}"
 Burgos,image03,103,active,1073741844,3ea6c91e241f256e5e3a88ebd647372022323a53,tenant1id,False,"{'type': 'ngimages', 'nid': 2, 'k3': 'v3'}"
+Burgos,image05,105,active,1073741864,44a6c91e241f256e5e3a88ebd647372022323a53,tenant1id,True,"{'type': 'wrongvalue', 'nid': 10, 'k4': 'v3'}"

--- a/tests/unit/resources/metadata/backup_Valladolid.csv
+++ b/tests/unit/resources/metadata/backup_Valladolid.csv
@@ -2,3 +2,4 @@ Valladolid,image01,001,active,1073741824,ddfe163345d338193ac2bdc183f8e9dcff904b4
 Valladolid,image02,002,active,1073741834,bcac9d1d8eab3713ae489224d0130c9468e7a0e3,tenant1id,True,"{'type': 'baseimage', 'k1': 'v1'}"
 Valladolid,image03,003,active,1073741844,3ea6c91e241f256e5e3a88ebd647372022323a53,tenant1id,False,"{'type': 'ngimages', 'nid': 2, 'k3': 'v3'}"
 Valladolid,image04,004,active,1073741854,798f861ee74f6ff83ccbc9c53b419941d0080e50,tenant1id,True,"{'type': 'other', 'k1' : 'value1'}"
+Valladolid,image05,005,active,1073741864,44a6c91e241f256e5e3a88ebd647372022323a53,tenant1id,True,"{'type': 'ngimages', 'k3': 'v3'}"


### PR DESCRIPTION
#### Reviewers

@flopezag 
#### Description

The bug is about bad synchronization of a property. If a property included in metadata_set is in the target region but not in the master region, then the property should be deleted from the target region image.

A test has been modified to  detect this case. However, the tests runs without errors.

Probably this problem has been fixed in another change.
#### Testing

Locally
