### PR TITLE
Fixing behavior if metadata_set is not defined. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,7 @@ This is the algorithm to determine if an image is synchronisable:
    that is a dictionary with the metadata of the image. Other properties are *id*,
    *name*, *owner*, *size*, *region*, *is_public*. The image may be synchronised
    even if it is not public, to avoid this, check ``image.is_public`` in the condition.
+   If ``metadata_set`` is not defined the image would not be synchronised.
 6) if ``metadata_condition`` is not defined, the image is public, and
    ``metadata_set`` is defined, the image is synchronised if some of the
    properties of ``metadata_set`` is on ``image.user_properties``.

--- a/glancesync/glancesync_image.py
+++ b/glancesync/glancesync_image.py
@@ -267,6 +267,8 @@ class GlanceSyncImage(object):
             globals_dict['image'] = self
             globals_dict['metadata_set'] = metadata_set
             synchronisable = eval(metadata_condition, globals_dict)
+            if not metadata_set:
+                synchronisable = False
         elif not self.is_public:
             synchronisable = False
         elif not metadata_set:

--- a/tests/acceptance/features/glancesync/metadata_image.feature
+++ b/tests/acceptance/features/glancesync/metadata_image.feature
@@ -130,7 +130,6 @@ Feature: Image sync between regions using GlanceSync in the same federation but
             | 'fake, fake'           |              |               |              |               |
 
 
-    @skip @bug @CLAUDIA-5306
     Scenario: 05: All metadata are synchronized when metadata_set property is empty
       Given a new image created in the Glance of master node with name "qatesting01" and these properties
               | param_name      | param_value         |
@@ -142,13 +141,7 @@ Feature: Image sync between regions using GlanceSync in the same federation but
               | DEFAULT         | metadata_condition  | image.is_public        |
               | DEFAULT         | metadata_set        |                        |
       When  I sync the image
-      Then  all images are synchronized
-      And   the image "qatesting01" is present in all nodes with the expected data
-      And   the properties values of the image "qatesting01" in all nodes are the following:
-              | param_name      | param_value         |
-              | sdc_aware       | True                |
-              | type            | fiware:apps         |
-              | nid             | 453                 |
+      Then  no images are synchronized
 
 
     @skip @bug @CLAUDIA-5307 @CLAUDIA-5308

--- a/tests/acceptance/features/glancesync/metadata_image.feature
+++ b/tests/acceptance/features/glancesync/metadata_image.feature
@@ -130,7 +130,7 @@ Feature: Image sync between regions using GlanceSync in the same federation but
             | 'fake, fake'           |              |               |              |               |
 
 
-    Scenario: 05: All metadata are synchronized when metadata_set property is empty
+    Scenario: 05: Images are not synchronized if metadata_set property is empty
       Given a new image created in the Glance of master node with name "qatesting01" and these properties
               | param_name      | param_value         |
               | sdc_aware       | True                |


### PR DESCRIPTION
#### REVIEWERS

@flopezag @jicarretero @pratid 
#### DESCRIPTION
- The image is not synchronized if metadata_set is undefined
- Acceptance test enabled.
#### TESTING
- Locally
- With acceptance test against experimentation environment
