### PR TITLE
Fixing behavior if metadata_set is not defined.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,8 @@ This is the algorithm to determine if an image is synchronisable:
    that is a dictionary with the metadata of the image. Other properties are *id*,
    *name*, *owner*, *size*, *region*, *is_public*. The image may be synchronised
    even if it is not public, to avoid this, check ``image.is_public`` in the condition.
+   If metadata_set is not defined and ``image.is_public``, then the image will be synchronised
+   with all ``user_properties``.
 6) if ``metadata_condition`` is not defined, the image is public, and
    ``metadata_set`` is defined, the image is synchronised if some of the
    properties of ``metadata_set`` is on ``image.user_properties``.

--- a/glancesync/glancesync.py
+++ b/glancesync/glancesync.py
@@ -439,10 +439,11 @@ class GlanceSync(object):
         # filter properties to upload
         metadata_set = regionobj.target['metadata_set']
         properties = list(new_image.user_properties.keys())
-        for p in properties:
-            if p not in metadata_set and \
-                    p != 'kernel_id' and p != 'ramdisk_id':
-                del new_image.user_properties[p]
+        if len(metadata_set) > 0:
+            for p in properties:
+                if p not in metadata_set and \
+                        p != 'kernel_id' and p != 'ramdisk_id':
+                    del new_image.user_properties[p]
 
         # upload
         uuid = regionobj.target['facade'].upload_image(

--- a/glancesync/glancesync.py
+++ b/glancesync/glancesync.py
@@ -437,13 +437,12 @@ class GlanceSync(object):
         glancesync_ami.update_kernelramdisk_id(
             new_image, master_image, images_dict)
         # filter properties to upload
-        metadata_set = regionobj.target['metadata_set']
-        properties = list(new_image.user_properties.keys())
+        metadata_set = set(regionobj.target['metadata_set'])
+        properties = set(new_image.user_properties.keys())
         if len(metadata_set) > 0:
-            for p in properties:
-                if p not in metadata_set and \
-                        p != 'kernel_id' and p != 'ramdisk_id':
-                    del new_image.user_properties[p]
+            diff = properties - metadata_set - set(['kernel_id', 'ramdisk_id'])
+            for p in diff:
+                del new_image.user_properties[p]
 
         # upload
         uuid = regionobj.target['facade'].upload_image(

--- a/tests/acceptance/features/glancesync/metadata_image.feature
+++ b/tests/acceptance/features/glancesync/metadata_image.feature
@@ -130,7 +130,6 @@ Feature: Image sync between regions using GlanceSync in the same federation but
             | 'fake, fake'           |              |               |              |               |
 
 
-    @skip @bug @CLAUDIA-5306
     Scenario: 05: All metadata are synchronized when metadata_set property is empty
       Given a new image created in the Glance of master node with name "qatesting01" and these properties
               | param_name      | param_value         |

--- a/tests/acceptance/features/glancesync/synchronization_forcesync.feature
+++ b/tests/acceptance/features/glancesync/synchronization_forcesync.feature
@@ -99,7 +99,7 @@ Feature: Image sync between regions using GlanceSync in the same federation with
             | att4            | False               |
 
 
-  Scenario: Sync images although the do not comply sync conditions: Public image with metadata and metadata_set. No checksum conflicts.
+  Scenario: Sync images although they do not comply sync conditions: Public image with metadata and metadata_set. No checksum conflicts.
     Given a new image created in the Glance of master node with name "qatesting01" and these properties:
             | param_name      | param_value         |
             | is_public       | False               |

--- a/tests/acceptance/features/glancesync/synchronization_forcesync.feature
+++ b/tests/acceptance/features/glancesync/synchronization_forcesync.feature
@@ -96,6 +96,7 @@ Feature: Image sync between regions using GlanceSync in the same federation with
     And   the properties values of the image "qatesting01" in all target nodes are the following:
             | param_name      | param_value         |
             | is_public       | False               |
+            | att4            | False               |
 
 
   Scenario: Sync images although the do not comply sync conditions: Public image with metadata and metadata_set. No checksum conflicts.


### PR DESCRIPTION
#### REVIEWERS

@flopezag @jicarretero @pratid 
#### DESCRIPTION
- The image is synchronized if metadata_set is undefined and image.ispublic
- Acceptance test enabled.
- Fixed behavior of a forcesync acceptance test
#### TESTING
- Locally
- With acceptance test against experimentation environment
